### PR TITLE
User inactive

### DIFF
--- a/auth/controller/CRUDController.py
+++ b/auth/controller/CRUDController.py
@@ -153,6 +153,7 @@ def deleteUser(dbSession, user):
         cache.deleteKey(userid=user.id)
         # The user is not hardDeleted.
         # it should be copied to inactiveUser table
+        inactiveTables.PasswdInactive.createInactiveFromUser(dbSession, user)
         inactiveTables.UserInactive.createInactiveFromUser(dbSession, user)
         dbSession.delete(user)
     except sqlalchemy.orm.exc.NoResultFound:

--- a/auth/controller/CRUDController.py
+++ b/auth/controller/CRUDController.py
@@ -10,6 +10,7 @@ from database.Models import Permission, User, Group, PermissionEnum
 from database.Models import UserPermission, GroupPermission, UserGroup
 from database.flaskAlchemyInit import HTTPRequestError
 import database.Cache as cache
+import database.historicModels as inactiveTables
 
 
 # Helper function to check user fields
@@ -154,6 +155,10 @@ def deleteUser(dbSession, user):
             UserGroup.__table__.delete(UserGroup.user_id == user.id)
         )
         cache.deleteKey(userid=user.id)
+        # The user is not hardDeleted.
+        # it should be copied to inactiveUser table
+        inactive = inactiveTables.UserInactive.createInactiveFromUser(user)
+        dbSession.add(inactive)
         dbSession.delete(user)
     except sqlalchemy.orm.exc.NoResultFound:
         raise HTTPRequestError(404, "No user found with this ID")

--- a/auth/controller/CRUDController.py
+++ b/auth/controller/CRUDController.py
@@ -2,10 +2,8 @@
 # delete Users, groups and permissions
 import sqlalchemy
 import re
-import os
-import binascii
-from pbkdf2 import crypt
 
+import controller.PasswordController as passwd
 from database.Models import Permission, User, Group, PermissionEnum
 from database.Models import UserPermission, GroupPermission, UserGroup
 from database.flaskAlchemyInit import HTTPRequestError
@@ -73,10 +71,8 @@ def createUser(dbSession, user):
         pass
     else:
         raise HTTPRequestError(400, "Email '" + user['email'] + "' is in use.")
-    user['salt'] = str(binascii.hexlify(os.urandom(8)), 'ascii')
-    user['hash'] = crypt(user['passwd'], user['salt'], 1000).split('$').pop()
+    user['salt'], user['hash'] = passwd.create(user['passwd'])
     del user['passwd']
-
     user = User(**user)
     return user
 
@@ -129,9 +125,9 @@ def updateUser(dbSession, user, updatedInfo):
             pass
 
     if 'passwd' in updatedInfo.keys():
-        oldUser.salt = str(binascii.hexlify(os.urandom(8)), 'ascii')
-        oldUser.hash = crypt(updatedInfo['passwd'],
-                             oldUser.salt, 1000).split('$').pop()
+        oldUser.salt, oldUser.hash = passwd.update(dbSession,
+                                                   oldUser,
+                                                   updatedInfo['passwd'])
         del updatedInfo['passwd']
 
     # TODO: find a iterative way
@@ -157,8 +153,7 @@ def deleteUser(dbSession, user):
         cache.deleteKey(userid=user.id)
         # The user is not hardDeleted.
         # it should be copied to inactiveUser table
-        inactive = inactiveTables.UserInactive.createInactiveFromUser(user)
-        dbSession.add(inactive)
+        inactiveTables.UserInactive.createInactiveFromUser(dbSession, user)
         dbSession.delete(user)
     except sqlalchemy.orm.exc.NoResultFound:
         raise HTTPRequestError(404, "No user found with this ID")

--- a/auth/controller/PasswordController.py
+++ b/auth/controller/PasswordController.py
@@ -1,0 +1,35 @@
+# This file contains function that implement password
+# related policies
+
+import binascii
+from pbkdf2 import crypt
+import os
+
+from database.flaskAlchemyInit import HTTPRequestError
+from database.historicModels import PasswdInactive
+
+
+def create(passwd):
+    # TODO: check password format policies
+    salt = str(binascii.hexlify(os.urandom(8)), 'ascii')
+    hash = crypt(passwd, salt, 1000).split('$').pop()
+    return salt, hash
+
+
+# update a passwd.
+# verify if the new passwd was used before
+# save the current passwd on inative table
+def update(dbSession, user, newPasswd):
+    # check actual passwd
+    if user.hash == crypt(newPasswd, user.salt, 1000).split('$').pop():
+        raise HTTPRequestError(400, "Please, choose a password"
+                                    " not used before")
+
+    # check all old password from database
+    oldpwd = dbSession.query(PasswdInactive).filter_by(user_id=user.id).all()
+    for pwd in oldpwd:
+        if pwd.hash == crypt(newPasswd, pwd.salt, 1000).split('$').pop():
+            raise HTTPRequestError(400, "Please, choose a password"
+                                        " not used before")
+    PasswdInactive.createInactiveFromUser(dbSession, user)
+    return create(newPasswd)

--- a/auth/controller/RelationshipController.py
+++ b/auth/controller/RelationshipController.py
@@ -46,6 +46,24 @@ def removeUserGroup(dbSession, user, group):
         raise HTTPRequestError(404, "User is not a member of the group")
 
 
+# add a user to a list of groups
+def addUserManyGroups(dbSession, user, groups):
+    success = []
+    failed = []
+
+    # if a single group was given. convert to a one element list
+    if not isinstance(groups, list):
+        groups = [groups]
+
+    for g in groups:
+        try:
+            addUserGroup(dbSession, user, g)
+            success.append(g)
+        except HTTPRequestError:
+            failed.append(g)
+    return success, failed
+
+
 def addGroupPermission(dbSession, group, permissionId):
     try:
         group = Group.getByNameOrID(group)

--- a/auth/database/Models.py
+++ b/auth/database/Models.py
@@ -1,10 +1,11 @@
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy import Column, String, Integer, Boolean
+from sqlalchemy import Column, String, Integer, Boolean, DateTime
 from sqlalchemy import ForeignKey, Enum, PrimaryKeyConstraint
 from sqlalchemy.orm import relationship, backref
 from sqlalchemy.orm import sessionmaker
 from flask_sqlalchemy import SQLAlchemy
 import enum
+import datetime
 
 import conf as dbconf
 from .flaskAlchemyInit import app, db
@@ -86,6 +87,8 @@ class User(db.Model):
     key = Column(String, nullable=False)
     kongId = Column(String, nullable=False)
 
+    created_date = Column(DateTime, default=datetime.datetime.utcnow)
+
     # Table Relationships
     permissions = relationship('Permission',
                                secondary='user_permission')
@@ -117,6 +120,7 @@ class Group(db.Model):
     name = Column(String(50), unique=True, nullable=False)
     description = Column(String, nullable=True)
 
+    created_date = Column(DateTime, default=datetime.datetime.utcnow)
     # Table ralationships
     permissions = relationship('Permission',
                                secondary='group_permission')

--- a/auth/database/historicModels.py
+++ b/auth/database/historicModels.py
@@ -1,0 +1,58 @@
+# This file contains models for inative users and passwords.
+# These kind of information should not be hard removed
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy import Column, String, Integer, Boolean, DateTime
+import datetime
+
+import conf as dbconf
+from .Models import User
+from .flaskAlchemyInit import app, db
+
+# a list of special fields present on all historic tables
+# this list is necessary to avoid 'AttributeError' when coping from
+# non-history objects
+historicFields = ['deletion_date']
+
+
+class UserInactive(db.Model):
+    __tablename__ = 'user_inactive'
+
+    id = Column(Integer, primary_key=True, autoincrement=False)
+    name = Column(String, nullable=False)
+    username = Column(String(50), nullable=False)
+    service = Column(String, nullable=False)
+    email = Column(String, nullable=False, unique=True)
+    created_date = Column(DateTime, nullable=False)
+    deletion_date = Column(DateTime, default=datetime.datetime.utcnow)
+
+    # Kong and passwd related fields don't need to be registered on historic
+    def createInactiveFromUser(user):
+        userInactiveDict = {
+                                c.name: getattr(user, c.name)
+                                for c in UserInactive.__table__.columns
+                                if c.name not in historicFields
+                            }
+
+        inactiveUser = UserInactive(**userInactiveDict)
+        return inactiveUser
+
+
+class PasswdInactive(db.Model):
+    __tablename__ = 'user_inactive'
+
+    user_id = Column(Integer, autoincrement=False)
+    hash = Column(String, nullable=False)
+    salt = Column(String, nullable=False)
+    deletion_date = Column(DateTime, default=datetime.datetime.utcnow)
+
+    def createInactiveFromUser(user):
+        pwdInactiveDict = {
+                                c.name: getattr(user, c.name)
+                                for c in UserInactive.__table__.columns
+                                if c.name not in historicFields
+                            }
+
+        inactivePwd = PasswdInactive(**pwdInactiveDict)
+        user.hash = None
+        user.salt = None
+        return inactivePwd

--- a/auth/database/historicModels.py
+++ b/auth/database/historicModels.py
@@ -25,7 +25,10 @@ class UserInactive(db.Model):
     created_date = Column(DateTime, nullable=False)
     deletion_date = Column(DateTime, default=datetime.datetime.utcnow)
 
-    # Kong and passwd related fields don't need to be registered on historic
+    # Kong related fields don't need to be registered on historic
+    # password related fields are stored on passwd_inactive table
+
+    # receives a user model object and save it on inactive table
     def createInactiveFromUser(dbSession, user):
         userInactiveDict = {
                                 c.name: getattr(user, c.name)
@@ -48,6 +51,7 @@ class PasswdInactive(db.Model):
     salt = Column(String, nullable=False)
     deletion_date = Column(DateTime, default=datetime.datetime.utcnow)
 
+    # receives a user model object and save its passwd on inactive table
     def createInactiveFromUser(dbSession, user):
         pwdInactiveDict = {
                             'user_id': user.id,

--- a/auth/webRoutes.py
+++ b/auth/webRoutes.py
@@ -88,7 +88,7 @@ def getUser(user):
 def updateUser(user):
     try:
         authData = loadJsonFromRequest(request)
-        oldUser = crud.updateUser(db.session, userid, authData)
+        oldUser = crud.updateUser(db.session, user, authData)
 
         # Create a new kong secret and delete the old one
         kongData = kong.configureKong(oldUser.username)

--- a/auth/webRoutes.py
+++ b/auth/webRoutes.py
@@ -53,8 +53,16 @@ def createUser():
 
         db.session.add(newUser)
         db.session.commit()
+        groupSuccess = []
+        groupFailed = []
+        if 'profile' in authData.keys():
+            groupSuccess, groupFailed = rship. \
+                addUserManyGroups(db.session, newUser.id, authData['profile'])
+        db.session.commit()
         return make_response(json.dumps({
                                         "user": newUser.safeDict(),
+                                        "groups": groupSuccess,
+                                        "could not add": groupFailed,
                                         "message": "user created"
                                         }), 200)
     except HTTPRequestError as err:


### PR DESCRIPTION
Deleted user data is now moved to another table.
Users can´t use the same password twice.
Users can be add to groups on creation. The 'profile' field is threatened as a group (or a list of groups) name to add the user.
This PR closes dojot/dojot#87 and closes dojot/dojot#88