### PR TITLE
Password reset

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,5 +135,5 @@ We use [pyresttest](https://github.com/svanoort/pyresttest) format for the test 
 You can run the test with:
 
 ```shell
-python resttest.py "http://localhost:port" test/<TEST_FILE>.yaml
+python resttest.py "http://authhost:port" test/<TEST_FILE>.yaml
 ```

--- a/appRun.sh
+++ b/appRun.sh
@@ -7,7 +7,7 @@ rc=$?; if [[ $rc != 0 ]]; then exit $rc; fi
 cd auth
 
 # create database tables
-echo -e "from webRoutes import db\ndb.create_all()" | python3 > /dev/null
+python3 -c "from webRoutes import db; db.create_all()"   > /dev/null
 
 # create predefined users and groups
 python3 /usr/src/app/auth/initialConf.py

--- a/auth/conf.py
+++ b/auth/conf.py
@@ -3,7 +3,6 @@
 
 import os
 
-
 # database related configuration
 dbName = os.environ.get("AUTH_DB_NAME", "postgres")
 dbUser = os.environ.get("AUTH_DB_USER", "auth")
@@ -39,6 +38,16 @@ emailTLS = (os.environ.get("AUTH_EMAIL_TLS", "true") in
 emailUsername = os.environ.get("AUTH_EMAIL_USER", "")
 emailPasswd = os.environ.get("AUTH_EMAIL_PASSWD", "")
 
+# if you are using a front end with Auth,
+# define this link to point to the password reset view on you FE
+resetPwdView = os.environ.get("AUTH_RESET_PWD_VIEW",
+                              "https://localhost:5000/passwd/resetlink")
+
+# if EMAIL_HOST is set to NOEMAIL a temporary password is given to
+# new users
+temporaryPassword = os.environ.get("AUTH_USER_TMP_PWD", "temppwd")
+
+
 # passwd policies configuration
 # time to expire an password reset link in minutes
 passwdRequestExpiration = int(os.environ.get("AUTH_PASSWD_REQUEST_EXP", 30))
@@ -63,4 +72,4 @@ if (emailHost != 'NOEMAIL' and not emailTLS):
 
 if (kongURL == 'DISABLED' and not checkJWTSign):
     print('Warning: Disabling KONG_URL and TOKEN_CHECK_SIGN is dangerous, as'
-          ' auth have no way to guarantee a JWT token is valid')
+          ' auth has no way to guarantee a JWT token is valid')

--- a/auth/conf.py
+++ b/auth/conf.py
@@ -32,7 +32,7 @@ checkJWTSign = (os.environ.get("AUTH_TOKEN_CHECK_SIGN", "FALSE") in
                 ['true', 'True', 'TRUE'])
 
 # email related configuration
-emailHost = os.environ.get("AUTH_EMAIL_HOST", "")
+emailHost = os.environ.get("AUTH_EMAIL_HOST", "NOEMAIL")
 emailPort = int(os.environ.get("AUTH_EMAIL_PORT", 587))
 emailTLS = (os.environ.get("AUTH_EMAIL_TLS", "true") in
             ['true', 'True', 'TRUE'])
@@ -49,6 +49,10 @@ passwdHistoryLen = int(os.environ.get("AUTH_PASSWD_HISTORY_LEN", 4))
 
 # make some configuration checks
 # and warn if dangerous configuration is found
+if (emailHost == 'NOEMAIL'):
+    print("MAIL_HOST set to NOEMAIL. This is unsafe"
+          " and there's no way to reset users forgotten password")
+
 if (emailHost != 'NOEMAIL' and
    (len(emailUsername) == 0 or len(emailPasswd) == 0)):
     print('Invalid configuration: No EMAIL_USER or EMAIL_PASSWD defined'

--- a/auth/conf.py
+++ b/auth/conf.py
@@ -34,9 +34,29 @@ checkJWTSign = (os.environ.get("AUTH_TOKEN_CHECK_SIGN", "FALSE") in
 # email related configuration
 emailHost = os.environ.get("AUTH_EMAIL_HOST", "")
 emailPort = int(os.environ.get("AUTH_EMAIL_PORT", 587))
+emailTLS = (os.environ.get("AUTH_EMAIL_TLS", "true") in
+            ['true', 'True', 'TRUE'])
 emailUsername = os.environ.get("AUTH_EMAIL_USER", "")
 emailPasswd = os.environ.get("AUTH_EMAIL_PASSWD", "")
 
 # passwd policies configuration
+# time to expire an password reset link in minutes
 passwdRequestExpiration = int(os.environ.get("AUTH_PASSWD_REQUEST_EXP", 30))
+# how many passwords should be check on the user history
+# to enforce no password repetition policy
 passwdHistoryLen = int(os.environ.get("AUTH_PASSWD_HISTORY_LEN", 4))
+
+
+# make some configuration checks
+# and warn if dangerous configuration is found
+if (emailHost != 'NOEMAIL' and
+   (len(emailUsername) == 0 or len(emailPasswd) == 0)):
+    print('Invalid configuration: No EMAIL_USER or EMAIL_PASSWD defined'
+          ' although a EMAIL_HOST was defined')
+
+if (emailHost != 'NOEMAIL' and not emailTLS):
+    print('Using e-mail without TLS is not safe')
+
+if (kongURL == 'DISABLED' and not checkJWTSign):
+    print('Disabling KONG_URL and TOKEN_CHECK_SIGN is dangerous, as'
+          ' auth have no way to guarantee a JWT token is valid')

--- a/auth/conf.py
+++ b/auth/conf.py
@@ -39,3 +39,4 @@ emailPasswd = os.environ.get("AUTH_EMAIL_PASSWD", "")
 
 # passwd policies configuration
 passwdRequestExpiration = int(os.environ.get("AUTH_PASSWD_REQUEST_EXP", 30))
+passwdHistoryLen = int(os.environ.get("AUTH_PASSWD_HISTORY_LEN", 4))

--- a/auth/conf.py
+++ b/auth/conf.py
@@ -50,7 +50,7 @@ passwdHistoryLen = int(os.environ.get("AUTH_PASSWD_HISTORY_LEN", 4))
 # make some configuration checks
 # and warn if dangerous configuration is found
 if (emailHost == 'NOEMAIL'):
-    print("MAIL_HOST set to NOEMAIL. This is unsafe"
+    print("Warning: MAIL_HOST set to NOEMAIL. This is unsafe"
           " and there's no way to reset users forgotten password")
 
 if (emailHost != 'NOEMAIL' and
@@ -59,8 +59,8 @@ if (emailHost != 'NOEMAIL' and
           ' although a EMAIL_HOST was defined')
 
 if (emailHost != 'NOEMAIL' and not emailTLS):
-    print('Using e-mail without TLS is not safe')
+    print('Warning: Using e-mail without TLS is not safe')
 
 if (kongURL == 'DISABLED' and not checkJWTSign):
-    print('Disabling KONG_URL and TOKEN_CHECK_SIGN is dangerous, as'
+    print('Warning: Disabling KONG_URL and TOKEN_CHECK_SIGN is dangerous, as'
           ' auth have no way to guarantee a JWT token is valid')

--- a/auth/conf.py
+++ b/auth/conf.py
@@ -30,3 +30,12 @@ tokenExpiration = int(os.environ.get("AUTH_TOKEN_EXP", 420))
 # query of overhead.
 checkJWTSign = (os.environ.get("AUTH_TOKEN_CHECK_SIGN", "FALSE") in
                 ['true', 'True', 'TRUE'])
+
+# email related configuration
+emailHost = os.environ.get("AUTH_EMAIL_HOST", "")
+emailPort = int(os.environ.get("AUTH_EMAIL_PORT", 587))
+emailUsername = os.environ.get("AUTH_EMAIL_USER", "")
+emailPasswd = os.environ.get("AUTH_EMAIL_PASSWD", "")
+
+# passwd policies configuration
+passwdRequestExpiration = int(os.environ.get("AUTH_PASSWD_REQUEST_EXP", 30))

--- a/auth/controller/AuthenticationController.py
+++ b/auth/controller/AuthenticationController.py
@@ -26,6 +26,9 @@ def authenticate(dbSession, authData):
     except sqlalchemy.orm.exc.NoResultFound:
         raise HTTPRequestError(401, 'not authorized')
 
+    if not user.hash:
+        raise HTTPRequestError(401, 'This user is inactive')
+
     if user.hash == crypt(passwd, user.salt, 1000).split('$').pop():
         groupsId = [g.id for g in user.groups]
 

--- a/auth/controller/CRUDController.py
+++ b/auth/controller/CRUDController.py
@@ -9,6 +9,7 @@ from database.Models import UserPermission, GroupPermission, UserGroup
 from database.flaskAlchemyInit import HTTPRequestError
 import database.Cache as cache
 import database.historicModels as inactiveTables
+import conf
 
 
 # Helper function to check user fields
@@ -21,13 +22,6 @@ def checkUser(user, ignore=[]):
                                'Invalid username. usernames should start with'
                                ' a letter and only lowercase,'
                                ' alhpanumeric and underscores are allowed')
-
-    if ('passwd' not in ignore) and (
-                                        'passwd' not in user.keys()
-                                        or len(user['passwd']) == 0
-                                    ):
-        # if password was not provided
-        raise HTTPRequestError(400, "Missing passwd")
 
     if 'service' not in user.keys() or len(user['service']) == 0:
         raise HTTPRequestError(400, "Missing service")
@@ -47,12 +41,15 @@ def checkUser(user, ignore=[]):
     if 'name' not in user.keys() or len(user['name']) == 0:
         raise HTTPRequestError(400, "Missing user's name (full name)")
 
+    if 'profile' not in user.keys() or len(user['profile']) == 0:
+        raise HTTPRequestError(400, "Missing profile")
+
     return user
 
 
 def createUser(dbSession, user):
     # drop invalid fields
-    user = {k: user[k] for k in user if k in User.fillable + ['passwd']}
+    user = {k: user[k] for k in user if k in User.fillable}
     checkUser(user)
 
     anotherUser = dbSession.query(User.id) \
@@ -66,8 +63,10 @@ def createUser(dbSession, user):
                            .filter_by(email=user['email']).one_or_none()
     if anotherUser:
         raise HTTPRequestError(400, "Email '" + user['email'] + "' is in use.")
-    user['salt'], user['hash'] = passwd.create(user['passwd'])
-    del user['passwd']
+
+    if conf.emailHost == 'NOEMAIL':
+        user['salt'], user['hash'] = passwd.create('temppwd')
+
     user = User(**user)
     return user
 
@@ -97,7 +96,7 @@ def updateUser(dbSession, user, updatedInfo):
     updatedInfo = {
                     k: updatedInfo[k]
                     for k in updatedInfo
-                    if k in User.fillable + ['passwd']
+                    if k in User.fillable
                   }
     oldUser = User.getByNameOrID(user)
 
@@ -105,10 +104,7 @@ def updateUser(dbSession, user, updatedInfo):
             and updatedInfo['username'] != oldUser.username:
         raise HTTPRequestError(400, "usernames can't be updated")
 
-    if 'passwd' not in updatedInfo.keys():
-        checkUser(updatedInfo, ['passwd'])
-    else:
-        checkUser(updatedInfo)
+    checkUser(updatedInfo)
 
     # Verify if the email is in use by another user
     if 'email' in updatedInfo.keys() and updatedInfo['email'] != oldUser.email:
@@ -118,13 +114,6 @@ def updateUser(dbSession, user, updatedInfo):
         if anotherUser:
             raise HTTPRequestError(400, "email already in use")
 
-    if 'passwd' in updatedInfo.keys():
-        oldUser.salt, oldUser.hash = passwd.update(dbSession,
-                                                   oldUser,
-                                                   updatedInfo['passwd'])
-        del updatedInfo['passwd']
-
-    # TODO: find a iterative way
     if 'name' in updatedInfo.keys():
         oldUser.name = updatedInfo['name']
     if 'service' in updatedInfo.keys():
@@ -145,10 +134,12 @@ def deleteUser(dbSession, user):
             UserGroup.__table__.delete(UserGroup.user_id == user.id)
         )
         cache.deleteKey(userid=user.id)
+
         # The user is not hardDeleted.
         # it should be copied to inactiveUser table
         inactiveTables.PasswdInactive.createInactiveFromUser(dbSession, user)
         inactiveTables.UserInactive.createInactiveFromUser(dbSession, user)
+        passwd.expirePasswordResetRequests(dbSession, user.id)
         dbSession.delete(user)
     except sqlalchemy.orm.exc.NoResultFound:
         raise HTTPRequestError(404, "No user found with this ID")

--- a/auth/controller/CRUDController.py
+++ b/auth/controller/CRUDController.py
@@ -65,7 +65,7 @@ def createUser(dbSession, user):
         raise HTTPRequestError(400, "Email '" + user['email'] + "' is in use.")
 
     if conf.emailHost == 'NOEMAIL':
-        user['salt'], user['hash'] = passwd.create('temppwd')
+        user['salt'], user['hash'] = passwd.create(conf.temporaryPassword)
 
     user = User(**user)
     return user

--- a/auth/controller/PasswordController.py
+++ b/auth/controller/PasswordController.py
@@ -97,7 +97,7 @@ def createPasswordResetRequest(dbSession, user):
 
     requestDict = {
                     'user_id': user['userid'],
-                    'link' = str(binascii.hexlify(os.urandom(16)), 'ascii')
+                    'link': str(binascii.hexlify(os.urandom(16)), 'ascii')
                   }
 
     passwdRequest = PasswordRequest(**requestDict)

--- a/auth/controller/PasswordController.py
+++ b/auth/controller/PasswordController.py
@@ -8,8 +8,9 @@ import sqlalchemy
 import datetime
 
 from database.flaskAlchemyInit import HTTPRequestError
-from database.historicModels import PasswdInactive
-from database.Models import PasswordRequest
+from database.historicModels import PasswdInactive, PasswordRequestInactive
+from database.Models import PasswordRequest, User
+from utils.emailUtils import sendMail
 import conf
 
 
@@ -30,35 +31,79 @@ def update(dbSession, user, newPasswd):
                                     " not used before")
 
     # check all old password from database
-    oldpwd = dbSession.query(PasswdInactive).filter_by(user_id=user.id).all()
-    for pwd in oldpwd:
-        if pwd.hash == crypt(newPasswd, pwd.salt, 1000).split('$').pop():
-            raise HTTPRequestError(400, "Please, choose a password"
-                                        " not used before")
+    if conf.passwdHistoryLen > 0:
+        oldpwds = (
+                    dbSession.query(PasswdInactive)
+                    .filter_by(user_id=user.id)
+                    .order_by(PasswdInactive.deletion_date.desc())
+                    .limit(conf.passwdHistoryLen)
+                   )
+
+        for pwd in oldpwds:
+            if pwd.hash == crypt(newPasswd, pwd.salt, 1000).split('$').pop():
+                raise HTTPRequestError(400, "Please, choose a password"
+                                            " not used before")
     PasswdInactive.createInactiveFromUser(dbSession, user)
     return create(newPasswd)
 
 
-def createPasswordResetRequest(dbSession, userId):
+# chech if a PasswordRequest expired
+# if it is, will be removed
+def chechRequestValidity(dbSession, resetRequest):
+    if ((resetRequest.created_date
+        + datetime.timedelta(minutes=conf.passwdRequestExpiration))
+            < datetime.datetime.utcnow()):
+        # save on inactive table before deletion
+        PasswordRequestInactive.createInactiveFromRequest(dbSession,
+                                                          resetRequest)
+        dbSession.delete(resetRequest)
+        dbSession.commit()
+        return False
+    else:
+        return True
+
+
+def resetPassword(dbSession, link, resetData):
+    if 'passwd' not in resetData.keys():
+        raise HTTPRequestError(400, 'missing password')
+    try:
+        resetRequest = dbSession.query(PasswordRequest). \
+            filter_by(link=link).one()
+        if chechRequestValidity(dbSession, resetRequest):
+            user = User.getByNameOrID(resetRequest.user_id)
+            user.salt, user.hash = update(dbSession, user, resetData['passwd'])
+            dbSession.add(user)
+
+            # remove this used reset request
+            PasswordRequestInactive.createInactiveFromRequest(dbSession,
+                                                              resetRequest)
+            dbSession.delete(resetRequest)
+        else:
+            raise HTTPRequestError(404, 'Page not found or expired')
+    except sqlalchemy.orm.exc.NoResultFound:
+        raise HTTPRequestError(404, 'Page not found or expired')
+
+
+def createPasswordResetRequest(dbSession, user):
     # veify if this user have and ative password reset request
     try:
         oldRequest = dbSession.query(PasswordRequest). \
-            filter_by(user_id=userId).one()
-        print(oldRequest.created_date)
-        print(type(oldRequest.created_date))
-        if ((oldRequest.created_date
-            + datetime.timedelta(minutes=conf.passwdRequestExpiration))
-                < datetime.datetime.now()):
-            dbSession.delete(oldRequest)
-            dbSession.commit()
-        else:
+            filter_by(user_id=user['userid']).one()
+        if chechRequestValidity(dbSession, oldRequest):
             raise HTTPRequestError(409, 'You have a password reset'
                                         ' request in progress')
     except sqlalchemy.orm.exc.NoResultFound:
         pass
 
-    requestDict = {'user_id': userId}
-    requestDict['link'] = str(binascii.hexlify(os.urandom(16)), 'ascii')
+    requestDict = {
+                    'user_id': user['userid'],
+                    'link' = str(binascii.hexlify(os.urandom(16)), 'ascii')
+                  }
 
     passwdRequest = PasswordRequest(**requestDict)
     dbSession.add(passwdRequest)
+
+    with open('templates/passwordReset.html', 'r') as f:
+        html = f.read()
+    html = html.format(name=user['name'], link=requestDict['link'])
+    sendMail(user['email'], 'Password Reset', html)

--- a/auth/controller/PasswordController.py
+++ b/auth/controller/PasswordController.py
@@ -131,7 +131,8 @@ def createPasswordResetRequest(dbSession, username):
 
     with open('templates/passwordReset.html', 'r') as f:
         html = f.read()
-    html = html.format(name=user.name, link=requestDict['link'])
+    resetLink = conf.resetPwdView + '?link=' + requestDict['link']
+    html = html.format(name=user.name, link=resetLink)
     sendMail(user.email, 'Password Reset', html)
 
 
@@ -147,8 +148,9 @@ def createPasswordSetRequest(dbSession, user):
 
     with open('templates/passwordSet.html', 'r') as f:
         html = f.read()
+    resetLink = conf.resetPwdView + '?link=' + requestDict['link']
     html = html.format(name=user.name,
-                       link=requestDict['link'],
+                       link=resetLink,
                        username=user.username)
     sendMail(user.email, 'Account Activation', html)
 

--- a/auth/database/Models.py
+++ b/auth/database/Models.py
@@ -79,8 +79,8 @@ class User(db.Model):
     service = Column(String, nullable=False)
     email = Column(String, nullable=False, unique=True)
     profile = Column(String, nullable=False)
-    hash = Column(String, nullable=False)
-    salt = Column(String, nullable=False)
+    hash = Column(String, nullable=True)
+    salt = Column(String, nullable=True)
 
     # These fields are configured by kong after user creation
     secret = Column(String, nullable=False)

--- a/auth/database/Models.py
+++ b/auth/database/Models.py
@@ -157,6 +157,15 @@ class UserGroup(db.Model):
                       primary_key=True, index=True)
 
 
+# table to keep the temporary password reset links
+class PasswordRequest(db.Model):
+    __tablename__ = 'passwd_request'
+
+    user_id = Column(Integer, primary_key=True, autoincrement=False)
+    link = Column(String, nullable=False, index=True)
+    created_date = Column(DateTime, default=datetime.datetime.utcnow)
+
+
 class MVUserPermission(db.Model):
     selectClause = db.select([UserPermission.user_id,
                              Permission.id,

--- a/auth/database/historicModels.py
+++ b/auth/database/historicModels.py
@@ -53,6 +53,8 @@ class PasswdInactive(db.Model):
 
     # receives a user model object and save its passwd on inactive table
     def createInactiveFromUser(dbSession, user):
+        if not user.hash:
+            return
         pwdInactiveDict = {
                             'user_id': user.id,
                             'hash': user.hash,

--- a/auth/database/historicModels.py
+++ b/auth/database/historicModels.py
@@ -61,3 +61,26 @@ class PasswdInactive(db.Model):
 
         inactivePwd = PasswdInactive(**pwdInactiveDict)
         dbSession.add(inactivePwd)
+
+
+class PasswordRequestInactive(db.Model):
+    __tablename__ = 'passwd_request_inactive'
+
+    # sqlAlchemy require a primary key on every table
+    inactive_id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(Integer, autoincrement=False)
+    link = Column(String, nullable=False, index=True)
+    created_date = Column(DateTime, nullable=False)
+    deletion_date = Column(DateTime, default=datetime.datetime.utcnow)
+
+    # receives a PasswordRequest model object and
+    # save its on the inactive table
+    def createInactiveFromRequest(dbSession, pwdRequest):
+        inactiveDict = {
+                        c.name: getattr(pwdRequest, c.name)
+                        for c in PasswordRequestInactive.__table__.columns
+                        if c.name not in historicFields
+                        }
+
+        inactiveRequest = PasswordRequestInactive(**inactiveDict)
+        dbSession.add(inactiveRequest)

--- a/auth/emailUtils.py
+++ b/auth/emailUtils.py
@@ -1,0 +1,26 @@
+import smtplib
+from email.mime.text import MIMEText
+import getpass
+
+
+import conf
+
+
+def sendMail(to, subject, htmlMsg):
+    msg = MIMEText(htmlMsg, 'html')
+
+    msg['Subject'] = subject
+    msg['From'] = conf.emailUsername
+    msg['To'] = to
+
+    s = smtplib.SMTP(conf.emailHost, conf.emailPort)
+    s.starttls()
+    passwd = getpass.getpass()
+    s.login(conf.emailUsername, passwd)
+
+    x = s.sendmail(conf.emailUsername, [to], msg.as_string())
+    s.quit()
+
+
+html = '<h1>A nice e-mail tittle</h1><p>A fine email body</p>'
+sendMail('lordale@yopmail.com', 'another example', html)

--- a/auth/initialConf.py
+++ b/auth/initialConf.py
@@ -28,12 +28,10 @@ def createUsers():
     for user in predefusers:
         # check if the user already exist
         # if the user exist, chances are this scrip has been run before
-        try:
-            anotherUser = db.session.query(User.id) \
-                                .filter_by(username=user['username']).one()
-        except sqlalchemy.orm.exc.NoResultFound:
-            pass
-        else:
+        anotherUser = db.session.query(User.id) \
+                                .filter_by(username=user['username']) \
+                                .one_or_none()
+        if anotherUser:
             print("That not the first container run. Skipping")
             exit(0)
 

--- a/auth/templates/passwordReset.html
+++ b/auth/templates/passwordReset.html
@@ -1,5 +1,4 @@
 <h2>Hello {name}. </h2>
 <p>Do you want to define a new passwd?</p>
-<p>follow the link to proceed: <a href="host/passwd/resetlink/{link}">LINK</p>
+<p>follow the link to proceed: <a href="{link}">LINK</a></p>
 <p>if you don't have requested a password reset ignore this e-mail.<p>
-<p>In fact.. this is just a test e-mail. so ignore it anyway</p>

--- a/auth/templates/passwordReset.html
+++ b/auth/templates/passwordReset.html
@@ -1,5 +1,5 @@
 <h2>Hello {name}. </h2>
 <p>Do you want to define a new passwd?</p>
-<p>follow the link to proceed: <a href="host/passwd/reset/{link}">LINK</p>
+<p>follow the link to proceed: <a href="host/passwd/resetlink/{link}">LINK</p>
 <p>if you don't have requested a password reset ignore this e-mail.<p>
 <p>In fact.. this is just a test e-mail. so ignore it anyway</p>

--- a/auth/templates/passwordReset.html
+++ b/auth/templates/passwordReset.html
@@ -1,0 +1,5 @@
+<h2>Hello {name}. </h2>
+<p>Do you want to define a new passwd?</p>
+<p>follow the link to proceed: <a href="host/passwd/reset/{link}">LINK</p>
+<p>if you don't have requested a password reset ignore this e-mail.<p>
+<p>In fact.. this is just a test e-mail. so ignore it anyway</p>

--- a/auth/templates/passwordSet.html
+++ b/auth/templates/passwordSet.html
@@ -1,0 +1,5 @@
+<h2>Hello {name}. </h2>
+<p>Your account has been created!</p>
+<p>Your username is {username}</p>
+<p>follow the link to activate your account
+  and create a password: <a href="host/passwd/resetlink/{link}">LINK</p>

--- a/auth/templates/passwordSet.html
+++ b/auth/templates/passwordSet.html
@@ -2,4 +2,4 @@
 <p>Your account has been created!</p>
 <p>Your username is {username}</p>
 <p>follow the link to activate your account
-  and create a password: <a href="host/passwd/resetlink/{link}">LINK</p>
+  and create a password: <a href="{link}">LINK</a></p>

--- a/auth/utils/emailUtils.py
+++ b/auth/utils/emailUtils.py
@@ -5,6 +5,8 @@ import conf
 
 
 def sendMail(to, subject, htmlMsg):
+    if conf.emailHost == 'NOEMAIL':
+        return
     msg = MIMEText(htmlMsg, 'html')
 
     msg['Subject'] = subject

--- a/auth/utils/emailUtils.py
+++ b/auth/utils/emailUtils.py
@@ -2,7 +2,6 @@ import smtplib
 from email.mime.text import MIMEText
 import getpass
 
-
 import conf
 
 
@@ -20,7 +19,3 @@ def sendMail(to, subject, htmlMsg):
 
     x = s.sendmail(conf.emailUsername, [to], msg.as_string())
     s.quit()
-
-
-html = '<h1>A nice e-mail tittle</h1><p>A fine email body</p>'
-sendMail('lordale@yopmail.com', 'another example', html)

--- a/auth/utils/emailUtils.py
+++ b/auth/utils/emailUtils.py
@@ -1,6 +1,5 @@
 import smtplib
 from email.mime.text import MIMEText
-import getpass
 
 import conf
 
@@ -13,7 +12,8 @@ def sendMail(to, subject, htmlMsg):
     msg['To'] = to
 
     s = smtplib.SMTP(conf.emailHost, conf.emailPort)
-    s.starttls()
+    if conf.emailTLS:
+        s.starttls()
     s.login(conf.emailUsername, conf.emailPasswd)
 
     x = s.sendmail(conf.emailUsername, [to], msg.as_string())

--- a/auth/utils/emailUtils.py
+++ b/auth/utils/emailUtils.py
@@ -14,8 +14,7 @@ def sendMail(to, subject, htmlMsg):
 
     s = smtplib.SMTP(conf.emailHost, conf.emailPort)
     s.starttls()
-    passwd = getpass.getpass()
-    s.login(conf.emailUsername, passwd)
+    s.login(conf.emailUsername, conf.emailPasswd)
 
     x = s.sendmail(conf.emailUsername, [to], msg.as_string())
     s.quit()

--- a/auth/webRoutes.py
+++ b/auth/webRoutes.py
@@ -390,7 +390,7 @@ def getGroupUsers(group):
 @app.route('/passwd/reset/<username>', methods=['POST'])
 def passwdResetRequest(username):
     if conf.emailHost == 'NOEMAIL':
-        return formatResponse(501, "Feature not configurated")
+        return formatResponse(501, "Feature not configured")
     try:
         pwdc.createPasswordResetRequest(db.session, username)
         db.session.commit()
@@ -401,9 +401,10 @@ def passwdResetRequest(username):
 
 
 # passwd related endpoints
-@app.route('/passwd/resetlink/<link>', methods=['POST'])
-def passwdReset(link):
+@app.route('/passwd/resetlink', methods=['POST'])
+def passwdReset():
     try:
+        link = request.args.get('link')
         resetData = loadJsonFromRequest(request)
         updatingUser = pwdc.resetPassword(db.session, link, resetData)
 

--- a/auth/webRoutes.py
+++ b/auth/webRoutes.py
@@ -426,6 +426,22 @@ def passwdReset(link):
         return formatResponse(200)
 
 
+@app.route('/passwd/update', methods=['POST'])
+def updatePasswd():
+    try:
+        token = request.headers.get('Authorization')
+        if not token:
+            return formatResponse(401, "not authorized")
+        userId = auth.getJwtPayload(token[7:])['userid']
+        updateData = loadJsonFromRequest(request)
+        pwdc.updateEndpoint(db.session, userId, updateData)
+        db.session.commit()
+    except HTTPRequestError as err:
+        return formatResponse(err.errorCode, err.message)
+    else:
+        return formatResponse(200)
+
+
 # endpoint for development use. Should be blocked on prodution
 @app.route('/admin/dropcache', methods=['DELETE'])
 def dropCache():

--- a/auth/webRoutes.py
+++ b/auth/webRoutes.py
@@ -60,6 +60,9 @@ def createUser():
             groupSuccess, groupFailed = rship. \
                 addUserManyGroups(db.session, newUser.id, authData['profile'])
         db.session.commit()
+        if conf.emailHost == 'NOEMAIL':
+            pwdc.createPasswordSetRequest(db.session, newUser)
+            db.session.commit()
         return make_response(json.dumps({
                                         "user": newUser.safeDict(),
                                         "groups": groupSuccess,
@@ -386,6 +389,8 @@ def getGroupUsers(group):
 # passwd related endpoints
 @app.route('/passwd/reset/<username>', methods=['POST'])
 def passwdResetRequest(username):
+    if conf.emailHost == 'NOEMAIL':
+        return formatResponse(501, "Feature not configurated")
     try:
         pwdc.createPasswordResetRequest(db.session, username)
         db.session.commit()

--- a/auth/webRoutes.py
+++ b/auth/webRoutes.py
@@ -381,11 +381,24 @@ def getGroupUsers(group):
 
 # passwd related endpoints
 @app.route('/passwd/reset', methods=['POST'])
-def passwdReset():
+def passwdResetRequest():
     try:
         token = request.headers.get('Authorization')
-        userId = auth.getJwtPayload(token[7:])['userid']
-        pwdc.createPasswordResetRequest(db.session, userId)
+        userJwt = auth.getJwtPayload(token[7:])
+        pwdc.createPasswordResetRequest(db.session, userJwt)
+        db.session.commit()
+    except HTTPRequestError as err:
+        return formatResponse(err.errorCode, err.message)
+    else:
+        return formatResponse(200)
+
+
+# passwd related endpoints
+@app.route('/passwd/reset/<link>', methods=['POST'])
+def passwdReset(link):
+    try:
+        resetData = loadJsonFromRequest(request)
+        pwdc.resetPassword(db.session, link, resetData)
         db.session.commit()
     except HTTPRequestError as err:
         return formatResponse(err.errorCode, err.message)

--- a/auth/webRoutes.py
+++ b/auth/webRoutes.py
@@ -15,6 +15,7 @@ import controller.RelationshipController as rship
 import controller.PDPController as pdpc
 import controller.AuthenticationController as auth
 import controller.ReportController as reports
+import controller.PasswordController as pwdc
 import kongUtils as kong
 from database.flaskAlchemyInit import app, db, formatResponse, \
                         HTTPRequestError, make_response, loadJsonFromRequest
@@ -378,6 +379,21 @@ def getGroupUsers(group):
         return make_response(json.dumps({"users": usersSafe}), 200)
 
 
+# passwd related endpoints
+@app.route('/passwd/reset', methods=['POST'])
+def passwdReset():
+    try:
+        token = request.headers.get('Authorization')
+        userId = auth.getJwtPayload(token[7:])['userid']
+        pwdc.createPasswordResetRequest(db.session, userId)
+        db.session.commit()
+    except HTTPRequestError as err:
+        return formatResponse(err.errorCode, err.message)
+    else:
+        return formatResponse(200)
+
+
+# endpoint for development use. Should be blocked on prodution
 @app.route('/admin/dropcache', methods=['DELETE'])
 def dropCache():
     cache.deleteKey()

--- a/test/test_user_crud.yaml
+++ b/test/test_user_crud.yaml
@@ -38,7 +38,7 @@
 - test:
     - group: "USER SANE CRUD"
     - name: "Make sure Mr alfred ISN'T there after we deleted him"
-    - url: "/user/alfred"
+    - url: "/user/alfred_testuser"
     - expected_status: [404]
 
 # invalid user create request
@@ -144,7 +144,7 @@
 
 - test:
     - group: "USER CREATE INVALID EMAIL"
-    - name: "Should not accept null emailt"
+    - name: "Should not accept null email"
     - url: "/user"
     - method: "POST"
     - body: '{
@@ -160,7 +160,7 @@
 
 - test:
     - group: "USER CREATE INVALID EMAIL"
-    - name: "Should not accept email zerlen"
+    - name: "Should not accept email zerolen"
     - url: "/user"
     - method: "POST"
     - body: '{


### PR DESCRIPTION
- Admins cannot define user passwords anymore.
- When a new user is created, an email is sent to its associated account with a link (token) for the user to activate his/hers account, by creating a password
- Authenticated users can change their own passwords
- Users are now allowed to repeat their passwords
- User data is not deleted anymore. Instead, user data is persisted in an "inactivee" table
- Add some configuration warnings
- When MAIL_HOST configuration option is set to 'NOEMAIL' new users are assigned a generic password.

This PR closes dojot/dojot#90