### PR TITLE
Password policies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.pyc
+password_blacklist.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pyc
+*.bin
 password_blacklist.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN pip3 install cython
 
 RUN mkdir -p /usr/src/app/requirements && mkdir /usr/src/app/auth \
     && wget https://raw.githubusercontent.com/danielmiessler/SecLists/master/Passwords/10_million_password_list_top_1000000.txt \
-    && cat 10_million_password_list_top_10000.txt \
+    && cat 10_million_password_list_top_1000000.txt \
       | sed -r '/^.{,5}$/d'  > /usr/src/app/auth/password_blacklist.txt
 
 WORKDIR /usr/src/app

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,11 @@ FROM python:3
 
 RUN pip3 install cython
 
-RUN mkdir -p /usr/src/app/requirements
+RUN mkdir -p /usr/src/app/requirements && mkdir /usr/src/app/auth \
+    && wget https://raw.githubusercontent.com/danielmiessler/SecLists/master/Passwords/10_million_password_list_top_1000000.txt \
+    && cat 10_million_password_list_top_10000.txt \
+      | sed -r '/^.{,5}$/d'  > /usr/src/app/auth/password_blacklist.txt
+
 WORKDIR /usr/src/app
 
 ADD . /usr/src/app

--- a/auth/conf.py
+++ b/auth/conf.py
@@ -78,3 +78,7 @@ if (emailHost != 'NOEMAIL' and not emailTLS):
 if (kongURL == 'DISABLED' and not checkJWTSign):
     print('Warning: Disabling KONG_URL and TOKEN_CHECK_SIGN is dangerous, as'
           ' auth has no way to guarantee a JWT token is valid')
+
+if (passwdMinLen < 6):
+    print("Password minlen can't be less than 6.")
+    passwdMinLen = 6

--- a/auth/conf.py
+++ b/auth/conf.py
@@ -57,6 +57,10 @@ passwdHistoryLen = int(os.environ.get("AUTH_PASSWD_HISTORY_LEN", 4))
 
 passwdMinLen = int(os.environ.get("AUTH_PASSWD_MIN_LEN", 8))
 
+
+passwdBlackList = os.environ.get("AUTH_PASSWD_BLACKLIST",
+                                 "password_blacklist.txt")
+
 # make some configuration checks
 # and warn if dangerous configuration is found
 if (emailHost == 'NOEMAIL'):

--- a/auth/conf.py
+++ b/auth/conf.py
@@ -55,6 +55,7 @@ passwdRequestExpiration = int(os.environ.get("AUTH_PASSWD_REQUEST_EXP", 30))
 # to enforce no password repetition policy
 passwdHistoryLen = int(os.environ.get("AUTH_PASSWD_HISTORY_LEN", 4))
 
+passwdMinLen = int(os.environ.get("AUTH_PASSWD_MIN_LEN", 8))
 
 # make some configuration checks
 # and warn if dangerous configuration is found

--- a/auth/controller/CRUDController.py
+++ b/auth/controller/CRUDController.py
@@ -65,7 +65,7 @@ def createUser(dbSession, user):
         raise HTTPRequestError(400, "Email '" + user['email'] + "' is in use.")
 
     if conf.emailHost == 'NOEMAIL':
-        user['salt'], user['hash'] = passwd.create(conf.temporaryPassword)
+        user['salt'], user['hash'] = passwd.createPwd(conf.temporaryPassword)
 
     user = User(**user)
     return user

--- a/auth/controller/PasswordController.py
+++ b/auth/controller/PasswordController.py
@@ -44,18 +44,34 @@ def checkPaswordFormat(user, passwd):
         raise HTTPRequestError(400, 'Please, choose a password'
                                     ' harder to guess')
 
-    # check for repeated consecutive characters
-    lastChar = ''
-    count = 1
+    # check for dull sequences
+    # like 'aaa' '123' 'abc'
+    lastChar = '\0'
+    countEquals = 1
+    countUp = 1
+    countDown = 1
     for c in passwd:
+        if (ord(c) == ord(lastChar) + 1):
+            countUp += 1
+        else:
+            countUp = 1
+
+        if (ord(c) == ord(lastChar) - 1):
+            countDown += 1
+        else:
+            countDown = 1
+
         if (c == lastChar):
             count += 1
-            if count == 3:
-                raise HTTPRequestError(400, 'do not use passwords with '
-                                            ' repetead characters sequence')
         else:
-            lastChar = c
             count = 1
+
+        if count == 3 or countUp == 3 or countDown == 3:
+            raise HTTPRequestError(400, 'do not use passwords with '
+                                        ' easy to guess'
+                                        'character sequences')
+
+        lastChar = c
 
     # check vs a dictionary
 

--- a/auth/controller/PasswordController.py
+++ b/auth/controller/PasswordController.py
@@ -108,7 +108,7 @@ def checkPaswordFormat(user, passwd):
     # check vs a blacklist
     if passwd in passwdBlackList:
         raise HTTPRequestError(400, "This password can't be used, as it is "
-                                    " our blacklist of bad passwords")
+                                    " in our blacklist of bad passwords")
 
 
 def createPwd(passwd):

--- a/auth/controller/PasswordController.py
+++ b/auth/controller/PasswordController.py
@@ -21,7 +21,7 @@ import conf
 def loadPasswordBlacklist():
     global passwdBlackList
     if conf.passwdBlackList == 'NOBLACKLIST':
-        print('No password blacklist file deined.')
+        print('No password blacklist file defined.')
         passwdBlackList = Trie()
         return
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -9,3 +9,4 @@ gunicorn==19.6.0
 gevent==1.1.1
 json-logging-py==0.2
 flask-redis==0.3.0
+marisa_trie==0.7.4


### PR DESCRIPTION
Auth wont permit unsafe and easy guessable passwords.
Passwords should have at least 6 characters (8 as default)
Password can´t contain part of the user name, user username or user email.
Can´t contain dummy sequences like '123' 'aaa'
Can´t be on a blacklist file (1M blacklist file by default)
The blacklist is implemented as a compiled suffix tree, its very fast!

This PR closes dojot/dojot#89