### PR TITLE
Adds pre-processed password blacklist file to repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.pyc
 *.bin
-password_blacklist.txt
 auth/logs
 .eggs
 auth.egg-info

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,7 @@ FROM python:3.6
 
 RUN pip3 install cython
 
-RUN mkdir -p /usr/src/app/requirements && mkdir /usr/src/app/auth \
-    && wget https://raw.githubusercontent.com/danielmiessler/SecLists/master/Passwords/10_million_password_list_top_1000000.txt \
-    && cat 10_million_password_list_top_1000000.txt \
-      | sed -r '/^.{,5}$/d'  > /usr/src/app/auth/password_blacklist.txt
-
+RUN mkdir -p /usr/src/app/requirements && mkdir /usr/src/app/auth 
 
 WORKDIR /usr/src/app
 


### PR DESCRIPTION
The file from whitch the set of blacklisted passwords was retrieved
has been removed from its original repo (danielmiessler/SecLists),
prompting the docker image building procedure to fail.

Since those haven't been updated in 2 years now, this commit adds
a local copy of the processed file in the repo, thus removing the
implicit relation to the "parent" repo.

This should fix dojot/auth#23