### PR TITLE
Fixing .travis.yml - deploy to pages uses relative paths

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ script:
   - aglio -i ./apis.apib -o apis.html
 
 deploy:
-  local_dir: ${TRAVIS_BUILD_DIR}/docs
+  local_dir: docs
   target_branch: gh-pages
   provider: pages
   skip_cleanup: true


### PR DESCRIPTION
deploying to github pages section now takes a relative path