### PR TITLE
Fix deploy to gh-pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,22 +13,6 @@ script:
   - 'docker build -t dredd-tests . -f ./tests/Dockerfile'
   - 'docker-compose -f ./tests/docker-compose.yml up -d auth-redis postgres'
   - 'docker-compose -f ./tests/docker-compose.yml run auth'
-  - if [ "${TRAVIS_BRANCH}" == "master" ]; then export VERSION="latest"; else export VERSION="${TRAVIS_BRANCH}"; fi
-  - node_modules/.bin/aglio -i ./docs/apiary.apib -o ./docs/apiary_${VERSION}.html
 after_success:
   - travis/publish.sh
-deploy:
-  - provider: pages
-    local-dir: ./docs
-    skip-cleanup: true
-    github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
-    keep-history: true
-    on:
-      branch: master
-  - provider: pages
-    local-dir: ./docs
-    skip-cleanup: true
-    github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
-    keep-history: true
-    on:
-      tags: true
+  - travis/deploy-gh-pages.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,14 +13,22 @@ script:
   - 'docker build -t dredd-tests . -f ./tests/Dockerfile'
   - 'docker-compose -f ./tests/docker-compose.yml up -d auth-redis postgres'
   - 'docker-compose -f ./tests/docker-compose.yml run auth'
-  - node_modules/.bin/aglio -i ./docs/apiary.apib -o ./docs/apiary_${TRAVIS_BRANCH}.html
+  - if [ "${TRAVIS_BRANCH}" == "master" ]; then export VERSION="latest"; else export VERSION="${TRAVIS_BRANCH}"; fi
+  - node_modules/.bin/aglio -i ./docs/apiary.apib -o ./docs/apiary_${VERSION}.html
 after_success:
   - travis/publish.sh
 deploy:
-  provider: pages
-  local-dir: ./docs
-  skip-cleanup: true
-  github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
-  keep-history: true
-  on:
-    branch: master
+  - provider: pages
+    local-dir: ./docs
+    skip-cleanup: true
+    github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
+    keep-history: true
+    on:
+      branch: master
+  - provider: pages
+    local-dir: ./docs
+    skip-cleanup: true
+    github-token: $GITHUB_TOKEN  # Set in travis-ci.org dashboard, marked secure
+    keep-history: true
+    on:
+      tags: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -183,7 +183,7 @@ numfig = True
 
 rst_epilog = """
     .. _Github pages API description: https://dojot.github.io/{0}/apiary_{1}.html
-""".format(project, os.environ['READTHEDOCS_PROJECT'], os.environ['READTHEDOCS_VERSION'])
+""".format(project, os.environ['READTHEDOCS_VERSION'])
 
 def setup(app):
     app.add_stylesheet('css/theme_overrides.css')

--- a/travis/deploy-gh-pages.sh
+++ b/travis/deploy-gh-pages.sh
@@ -1,0 +1,17 @@
+git checkout gh-pages
+git checkout ${TRAVIS_BRANCH} -- ./docs
+mv docs/* . 
+git rm -r docs
+
+if [ "${TRAVIS_BRANCH}" == "master" ]
+then 
+  export VERSION="latest"
+else 
+  export VERSION="${TRAVIS_BRANCH}"
+fi
+aglio -i apiary.apib -o apiary_${VERSION}.html
+
+git add apiary_${VERSION}.html
+git commit -m 'Updating gh-pages'
+git push http://${GITHUB_TOKEN}:x-oauth-basic@github.com/${TRAVIS_REPO_SLUG} gh-pages
+git checkout ${TRAVIS_BRANCH}

--- a/travis/deploy-gh-pages.sh
+++ b/travis/deploy-gh-pages.sh
@@ -9,7 +9,7 @@ then
 else 
   export VERSION="${TRAVIS_BRANCH}"
 fi
-aglio -i apiary.apib -o apiary_${VERSION}.html
+node_modules/.bin/aglio -i apiary.apib -o apiary_${VERSION}.html
 
 git add apiary_${VERSION}.html
 git commit -m 'Updating gh-pages'


### PR DESCRIPTION
This PR changes a bit how the rendered API blueprint is deployed to Github Pages. The default mechanism is this: travis will checkout gh-pages branch and then copy all the content from the folder selected in .travis.yml to the root folder. This will overwrite all previous files - the 'keep_history' flag means that a normal push will be performed, instead of a 'push force', which will rewrite commit history. As we want all the rendered API blueprints, this is not we are looking for.

This PR implements such deployment in a way that we can still retrieve the previous rendered versions of API blueprints - so that we can point to them from readthedocs documentation.