### PR TITLE
Makes rabbitMQ connection lazy

### DIFF
--- a/auth/database/flaskAlchemyInit.py
+++ b/auth/database/flaskAlchemyInit.py
@@ -6,12 +6,12 @@
  so it can be reused in any Flask + Alchemy project
 """
 
+import json
+import logging
 from flask import Flask
 from flask import make_response as fmake_response
-import json
 from flask_sqlalchemy import SQLAlchemy
 from logging.handlers import SysLogHandler
-import logging
 import conf as dbconf
 
 

--- a/auth/webRoutes.py
+++ b/auth/webRoutes.py
@@ -17,8 +17,8 @@ import controller.AuthenticationController as auth
 import controller.ReportController as reports
 import controller.PasswordController as pwdc
 import auth.kongUtils as kong
-from database.flaskAlchemyInit import app, db, format_response, \
-    HTTPRequestError, make_response, load_json_from_request
+from database.flaskAlchemyInit import app, db, format_response
+from database.flaskAlchemyInit import HTTPRequestError, make_response, load_json_from_request
 import database.Cache as cache
 
 from utils.serialization import json_serial


### PR DESCRIPTION
This changes the way auth initializes its connection to rabbitMQ - instead of initializing the "alarm library" on boot, this makes it so that it is only initialized when effectively needed. If initialization fails for one alarm, it is attempted again for the next.

This aims to avoid excessive restart attempts when a full environment is booting.

This is connected to dojot/auth#42