### PR TITLE
Reduce size docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM python:3.6
+FROM python:3.6-alpine
+# RUN apk add --no-cache gcc libc-dev unixodbc-dev py-psycopg2
+
+RUN apk update && apk add build-base postgresql-dev libffi-dev git libc6-compat linux-headers bash dumb-init
 
 RUN pip install cython
 
@@ -7,7 +10,7 @@ RUN mkdir -p /usr/src/app/requirements && mkdir /usr/src/app/auth
 WORKDIR /usr/src/app
 
 ADD ./requirements/requirements.txt /usr/src/app/requirements/
-RUN pip install -r requirements/requirements.txt
+RUN pip install -r requirements/requirements.txt && apk del gcc
 
 ADD . /usr/src/app
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This PR introduce a fix in auth image size.


* **What is the current behavior?** (You can also link to an open issue here)
Nowadays, image auth is with 1.01GB.

* **What is the new behavior (if this is a feature change)?**
With this changes, image size auth is with 366MB.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This PR is related to dojot/dojot#729

* **Other information**:
